### PR TITLE
Basic support for business accounts

### DIFF
--- a/src/common/account-types.ts
+++ b/src/common/account-types.ts
@@ -1,0 +1,4 @@
+export enum AccountType {
+    Consumer,
+    Business
+}

--- a/src/common/config/cognito.ts
+++ b/src/common/config/cognito.ts
@@ -1,0 +1,24 @@
+import { AccountType } from '../account-types';
+
+export interface CognitoConfig {
+    appClientId: string;
+    region: string;
+    userPoolId: string;
+}
+
+const COGNITO_CONFIG_PER_ACCOUNT_TYPE: Map<AccountType, CognitoConfig> = new Map([
+    [AccountType.Consumer, { appClientId: '7dum3ivsqng75jdve4sc39tve4', region: 'us-east-2', userPoolId: 'us-east-2_ej6SB5BPr' }],
+    [AccountType.Business, { appClientId: '2almd6su98hvm10i04o34co9at', region: 'us-east-2', userPoolId: 'us-east-2_My4WRmfXa' }]
+]);
+
+export class CognitoConfig {
+
+    public static getConfig(accountType: AccountType): CognitoConfig {
+        if (COGNITO_CONFIG_PER_ACCOUNT_TYPE.has(accountType)) {
+            return COGNITO_CONFIG_PER_ACCOUNT_TYPE.get(accountType);
+        } else {
+            throw new Error(`Login to ${AccountType[accountType]} accounts currently unsupported.`);
+        }
+    }
+
+}

--- a/src/public/app/account/account-type.service.ts
+++ b/src/public/app/account/account-type.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { CookieService } from 'ngx-cookie-service';
+
+import { AccountType } from '../../../common/account-types';
+import { FiduServiceBase } from '../common/fidu-service-base';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class AccountTypeService extends FiduServiceBase {
+
+    AccountType = AccountType;
+
+    public constructor(private cookieService: CookieService) {
+        super();
+    }
+
+    public accountTypeMatches(accountType: AccountType): boolean {
+        return accountType === this.getAccountType();
+    }
+
+    public getAccountType(): AccountType {
+        return Number(this.cookieService.get('AccountType'));
+    }
+
+    public getAccountTypeString(): string {
+        return AccountType[this.getAccountType()].toString();
+    }
+
+}

--- a/src/public/app/account/login/login.component.pug
+++ b/src/public/app/account/login/login.component.pug
@@ -12,6 +12,12 @@
     form(
         "[formGroup]"="loginForm"
         "(ngSubmit)"="login()")
+
+      .form-group
+        select.form-control(formControlName="AccountType")
+          option(value="" selected disabled) Account Type
+          option(*ngFor="let typeKey of accountTypeKeys" "[value]"="typeKey") {{accountTypeEnum[typeKey]}}
+          
       .form-group
         input.form-control(
             type="text"

--- a/src/public/app/account/login/login.component.ts
+++ b/src/public/app/account/login/login.component.ts
@@ -1,8 +1,9 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Params } from '@angular/router';
-
 import { CookieService } from 'ngx-cookie-service';
+
+import { AccountType } from '../../../../common/account-types';
 import { LOCATION } from '../../util/window-injections';
 import { AccountService } from '../account.service';
 
@@ -13,6 +14,8 @@ import { AccountService } from '../account.service';
 })
 export class LoginComponent implements OnInit {
 
+  public accountTypeEnum = AccountType;
+  public accountTypeKeys: any[];
   public error: string = null;
   public loginForm: FormGroup;
   public user: string = 'User';
@@ -27,8 +30,10 @@ export class LoginComponent implements OnInit {
       private service: AccountService) {
     this.loginForm = this.fb.group({
       Username: ['', Validators.required],
-      Password: ['', Validators.required]
+      Password: ['', Validators.required],
+      AccountType: ['', Validators.required]
     });
+    this.accountTypeKeys = Object.keys(AccountType).filter(f => !isNaN(Number(f)));
   }
 
   public login(): void {

--- a/src/public/app/account/model/user-authentication-data.ts
+++ b/src/public/app/account/model/user-authentication-data.ts
@@ -1,0 +1,5 @@
+export interface UserAuthenticationData {
+    AccountType: number;
+    Password?: string;
+    Username: string;
+}

--- a/src/public/app/account/user/account-settings/account-settings.component.pug
+++ b/src/public/app/account/user/account-settings/account-settings.component.pug
@@ -1,5 +1,5 @@
 .card
-  h5.card-header Account Settings
+  h5.card-header {{accountTypeService.getAccountTypeString()}} Account Settings
   ul.list-group.list-group-flush
     li.list-group-item.d-flex.justify-content-between
       div

--- a/src/public/app/account/user/account-settings/account-settings.component.spec.ts
+++ b/src/public/app/account/user/account-settings/account-settings.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CookieService } from 'ngx-cookie-service';
 
 import { UserInfo } from '../../model/user-info';
 import { UpdateAttributeComponent } from '../update-attribute/update-attribute.component';
@@ -22,6 +23,9 @@ describe('AccountSettingsComponent', () => {
       imports: [
         FormsModule,
         ReactiveFormsModule
+      ],
+      providers: [
+        CookieService
       ]
     })
     .compileComponents();

--- a/src/public/app/account/user/account-settings/account-settings.component.ts
+++ b/src/public/app/account/user/account-settings/account-settings.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
+import { AccountTypeService } from '../../account-type.service';
 import { UserInfo } from '../../model/user-info';
 
 @Component({
@@ -15,7 +16,7 @@ export class AccountSettingsComponent implements OnInit {
   private editingAttribute?: string = null;
   private modal?: NgbModalRef = null;
 
-  public constructor(private modalService: NgbModal) {
+  public constructor(private modalService: NgbModal, public accountTypeService: AccountTypeService) {
     this.clearAttrs = this.clearAttrs.bind(this);
   }
 

--- a/src/public/app/app.component.pug
+++ b/src/public/app/app.component.pug
@@ -19,7 +19,7 @@ header
       ul.navbar-nav.flex
         li.nav-item
           a.nav-link.text-sm-left.text-md-center
-            span.bg-danger.text-white.get-naloxone.text-nowrap(routerLink="/buy" "(click)"="toggleMenu()") Get Naloxone
+            span.bg-danger.text-white.get-naloxone.text-nowrap(routerLink="{{buyLink}}" "(click)"="toggleMenu()") Get Naloxone
         li.nav-item(ngbDropdown)
           a.nav-link.dropdown-toggle.text-sm-left.text-md-center(ngbDropdownToggle routerLink="/training") Training
           .dropdown-menu.text-center(ngbDropdownMenu)
@@ -48,7 +48,7 @@ header
         li.nav-item(ngbDropdown *ngIf="user.isAuthenticated()")
           a.nav-link.dropdown-toggle.text-sm-left.text-md-center(ngbDropdownToggle) {{user.name}}
           .dropdown-menu.text-center(ngbDropdownMenu)
-            a.dropdown-item.nav-link(routerLink="/account/user/profile") My Account
+            a.dropdown-item.nav-link(routerLink="/account/user/profile") My {{accountType}} Account
             a.dropdown-item.nav-link(routerLink="/account/logout") Logout
 
   .alert.alert-info(*ngIf="showCrisis" role="alert")

--- a/src/public/app/app.component.ts
+++ b/src/public/app/app.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+import { AccountType } from '../../common/account-types';
+import { AccountTypeService } from './account/account-type.service';
 import { AccountService } from './account/account.service';
 import { UserInfo } from './account/model/user-info';
 
@@ -10,14 +12,16 @@ import { UserInfo } from './account/model/user-info';
 })
 export class AppComponent implements OnInit {
 
+  accountType: string;
+  buyLink: string;
   isCollapsed: boolean = true;
-
   showCrisis: boolean = true;
-
   user: UserInfo;
 
-  public constructor(private loginService: AccountService) {
+  public constructor(private loginService: AccountService, private accountTypeService: AccountTypeService) {
     this.user = new UserInfo();
+    this.accountType = this.accountTypeService.getAccountTypeString();
+    this.buyLink = accountTypeService.accountTypeMatches(AccountType.Business) ? '/buy/b2b' : '/buy';
   }
 
   public dismissCrisis(): void {


### PR DESCRIPTION
* Supports logging in to either consumer or business account
* Cognito user pool config shared between server and client
* Support for detecting current logged in account type (e.g. to display different components for different account types)
* Display account type in a couple locations just for kicks to show that it works
* Change buy link (to /buy or /buy/b2b) depending on logged-in account type

LOTS is still TODO here, not the least of which is that you can't actually register a business account currently except directly in the Cognito console (registration still works, it just defaults to consumer accounts). This is basically just a POC to show that it works, show the shared configuration, etc. 

You *can* register a business account in the Cognito console, but you have to reset your password on first login which our UI currently doesn't support, so you have to do that through [this Cognito flow](https://naloxone-exchange-business-user-pool-test.auth.us-east-2.amazoncognito.com/login?response_type=token&client_id=2almd6su98hvm10i04o34co9at&redirect_uri=https://naloxoneexchange.com). 

To test these UI changes, you can hit my dev box at https://dan.dev.naloxoneexchange.com:8443/account/login. Your existing account will work as long as you select "Consumer", but if you want to test a Business account you'll need to create one through the Cognito console. 